### PR TITLE
Fix contentViewController height constraint priority

### DIFF
--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -344,7 +344,8 @@ public class SheetViewController: UIViewController {
             
             $0.centerX.alignWithSuperview()
             self.contentViewHeightConstraint = $0.height.set(self.height(for: self.currentSize))
-            
+	    self.contentViewHeightConstraint.priority = UILayoutPriority(999)
+
             let top: CGFloat
             if (self.options.useFullScreenMode) {
                 top = 0


### PR DESCRIPTION
When the content vc gets built it often gets set with a required height constraint of 0 which conflicts with its own constraints for its pullbar. 

I forked the repo to fix on my end but would love to not have to keep the fork.